### PR TITLE
Improve support for ssh config include directives

### DIFF
--- a/itermoxyl
+++ b/itermoxyl
@@ -5,6 +5,8 @@ import re
 import signal
 import subprocess
 import sys
+import glob
+import os
 from math import ceil
 from os.path import expanduser, normpath, join
 
@@ -60,7 +62,13 @@ def load_hosts(config_file_name="config", available_hosts=None):
 
             result = include_re.search(line)
             if result:
-                load_hosts(result.group(1), available_hosts)
+                for arg in result.group(1).replace('=', ' ').split(' '):
+                    if arg.startswith('~'):
+                        arg = os.path.expanduser(arg)
+                    elif not arg.startswith('/'):
+                        arg = CONFIG_PATH + arg
+                    for f in list(glob.glob(arg)):
+                        load_hosts(f, available_hosts)
 
             # look for `Host` lines
             result = host_re.search(line)


### PR DESCRIPTION
Process the Include directive as described in ssh_config:

Include
  Include the specified configuration file(s).  Multiple pathnames may
  be specified and each pathname may contain glob(7) wildcards and, for
  user configurations, shell-like `~' references to user home
  directories.  Files without absolute paths are assumed to be in ~/.ssh
  if included in a user configuration file or /etc/ssh if included from
  the system configuration file.  Include directive may appear inside a
  Match or Host block to perform conditional inclusion.

Multiple pathnames are seprated by spaces or '=', the same used by ssh
config project (readconf.c).